### PR TITLE
SCMOD-7472: Add standard logging format to startup scripts

### DIFF
--- a/release-notes-1.3.0.md
+++ b/release-notes-1.3.0.md
@@ -6,7 +6,7 @@ ${version-number}
 #### New Features
 - [SCMOD-6665](https://portal.digitalsafe.net/browse/SCMOD-6665): Add locale setting, update tini version to [v0.18.0](https://github.com/krallin/tini/releases/tag/v0.18.0)
 
-- [SCMOD-7472](https://portal.digitalsafe.net/browse/SCMOD-7472): The startup scripts logging format updated to use standard pattern as specified in [caf-logging](https://github.com/CAFapi/caf-logging).
+- SCMOD-7472: The startup scripts logging format updated to use standard pattern as specified in [caf-logging](https://github.com/CAFapi/caf-logging).
 
 #### Known Issues
 - None

--- a/release-notes-1.3.0.md
+++ b/release-notes-1.3.0.md
@@ -5,6 +5,6 @@ ${version-number}
 
 #### New Features
 
-- [SCMOD-7472](https://portal.digitalsafe.net/browse/SCMOD-7472): The startup scripts logging format updated to use standard pattern as mentioned in [caf-logging](https://github.com/CAFapi/caf-logging).
+- [SCMOD-7472](https://portal.digitalsafe.net/browse/SCMOD-7472): The startup scripts logging format updated to use standard pattern as specified in [caf-logging](https://github.com/CAFapi/caf-logging).
 
 #### Known Issues

--- a/release-notes-1.3.0.md
+++ b/release-notes-1.3.0.md
@@ -5,4 +5,6 @@ ${version-number}
 
 #### New Features
 
+- [SCMOD-7472](https://portal.digitalsafe.net/browse/SCMOD-7472): The startup scripts logging format updated to use standard pattern as mentioned in caf-logging.
+
 #### Known Issues

--- a/release-notes-1.3.0.md
+++ b/release-notes-1.3.0.md
@@ -5,6 +5,6 @@ ${version-number}
 
 #### New Features
 
-- [SCMOD-7472](https://portal.digitalsafe.net/browse/SCMOD-7472): The startup scripts logging format updated to use standard pattern as mentioned in caf-logging.
+- [SCMOD-7472](https://portal.digitalsafe.net/browse/SCMOD-7472): The startup scripts logging format updated to use standard pattern as mentioned in [caf-logging](https://github.com/CAFapi/caf-logging).
 
 #### Known Issues

--- a/src/main/docker/startup/startup.sh
+++ b/src/main/docker/startup/startup.sh
@@ -16,8 +16,9 @@
 #
 
 # Create a convenience function for logging
+processId = $BASHPID;
 log() {
-    echo "[$(date +%H:%M:%S.%3NZ) #$(printf '%03X\n' $BASHPID).??? INFO -            -   ] ${0##*/}: $@"
+    echo "[$(date +%H:%M:%S.%3NZ) #$(printf '%03X\n' $processId).??? INFO -            -   ] ${0##*/}: $@"
 }
 
 # Run the executable scripts that are in the drop-in folder

--- a/src/main/docker/startup/startup.sh
+++ b/src/main/docker/startup/startup.sh
@@ -29,7 +29,7 @@ for script in $(dirname "$0")/startup.d/*; do
         "$script" |& sed -ure "
             s/^warning:/WARN:/I;
             /^(info|error|warn|debug|trace):/I!s/^/info: /;
-            s/^(\w{0,4}):/\1 :/I;
+            s/^(\w{0,4}):/\1 :/;
             s/^([^:]*): ?(.*)$/[$(printf '%s' $currDateTime) #$(printf '%03X\n' $BASHPID).??? \U\1\E -            -   ] ${script##*/}: \2/"
     fi
 done

--- a/src/main/docker/startup/startup.sh
+++ b/src/main/docker/startup/startup.sh
@@ -25,12 +25,14 @@ log "Running startup scripts..."
 for script in $(dirname "$0")/startup.d/*; do
     if [ -x "$script" ]; then
         log "Running ${script##*/}..."
-        currDateTime=$(date +%H:%M:%S.%3NZ)
-        "$script" |& sed -ure "
+        "$script" |& sed -ure '
             s/^warning:/WARN:/I;
             /^(info|error|warn|debug|trace):/I!s/^/info: /;
             s/^(\w{0,4}):/\1 :/;
-            s/^([^:]*): ?(.*)$/[$(printf '%s' $currDateTime) #$(printf '%03X\n' $BASHPID).??? \U\1\E -            -   ] ${script##*/}: \2/"
+			s/^([^:]*): ?(.*)$/\1:'"${script##*/}"': \2/;
+			s/"/"'"'"'"'"'"'"/g;
+            s/^([^:]*):(.*)$/echo "[$(date +%H:%M:%S.%3NZ) #'"$(printf '%03X\n' $BASHPID)"'.??? \U\1\E -            -   ] \2"/;
+			e'
     fi
 done
 

--- a/src/main/docker/startup/startup.sh
+++ b/src/main/docker/startup/startup.sh
@@ -26,7 +26,7 @@ log "Running startup scripts..."
 for script in $(dirname "$0")/startup.d/*; do
     if [ -x "$script" ]; then
         log "Running ${script##*/}..."
-        "$script" |& sed -ure "s/^warning:/WARN:/I; /^(info|error|warn|debug|trace):/I!s/^/info: /; s/^([^:]*): ?(.*)$/[$(date +%H:%M:%S.%3NZ) #$(printf '%03X\n' $BASHPID).??? \U\1\E -            -   ] ${script##*/}: \2/I"
+        "$script" |& sed -ure "s/^warning:/WARN:/I; /^(info|error|warn|debug|trace):/I!s/^/info: /; s/^([^:]*): ?(.*)$/[$(date +%H:%M:%S.%3NZ) #$(printf '%03X\n' $BASHPID).??? \U\1\E -            -   ] ${script##*/}: \2/"
     fi
 done
 

--- a/src/main/docker/startup/startup.sh
+++ b/src/main/docker/startup/startup.sh
@@ -25,7 +25,7 @@ log "Running startup scripts..."
 for script in $(dirname "$0")/startup.d/*; do
     if [ -x "$script" ]; then
         log "Running ${script##*/}..."
-        "$script" |& sed -ue "s/^/${script##*/}: /"
+        "$script" |& sed -ure "s/^((info|error|warn|debug|trace): ?)?(.*)$/[$(date +%H:%M:%S.%3NZ) #$(printf '%03X\n' "$BASHPID").??? $(printf '%s\n' '\U\2\E')  -            - ]  ${script##*/}: \3/I"
     fi
 done
 

--- a/src/main/docker/startup/startup.sh
+++ b/src/main/docker/startup/startup.sh
@@ -16,9 +16,8 @@
 #
 
 # Create a convenience function for logging
-processId = $BASHPID;
 log() {
-    echo "[$(date +%H:%M:%S.%3NZ) #$(printf '%03X\n' $processId).??? INFO -            -   ] ${0##*/}: $@"
+    echo "[$(date +%H:%M:%S.%3NZ) #$(printf '%03X\n' $$).??? INFO -            -   ] ${0##*/}: $@"
 }
 
 # Run the executable scripts that are in the drop-in folder

--- a/src/main/docker/startup/startup.sh
+++ b/src/main/docker/startup/startup.sh
@@ -29,10 +29,10 @@ for script in $(dirname "$0")/startup.d/*; do
             s/^warning:/WARN:/I;
             /^(info|error|warn|debug|trace):/I!s/^/info: /;
             s/^(\w{0,4}):/\1 :/;
-			s/^([^:]*): ?(.*)$/\1:'"${script##*/}"': \2/;
-			s/"/"'"'"'"'"'"'"/g;
+            s/^([^:]*): ?(.*)$/\1:'"${script##*/}"': \2/;
+            s/"/"'"'"'"'"'"'"/g;
             s/^([^:]*):(.*)$/echo "[$(date +%H:%M:%S.%3NZ) #'"$(printf '%03X\n' $BASHPID)"'.??? \U\1\E -            -   ] \2"/;
-			e'
+            e'
     fi
 done
 

--- a/src/main/docker/startup/startup.sh
+++ b/src/main/docker/startup/startup.sh
@@ -26,7 +26,7 @@ for script in $(dirname "$0")/startup.d/*; do
     if [ -x "$script" ]; then
         log "Running ${script##*/}..."
         currDateTime=$(date +%H:%M:%S.%3NZ)
-        "$script" |& sed -ure "s/^warning:/WARN:/I; /^(info|error|warn|debug|trace):/I!s/^/info: /; s/^([^:]*): ?(.*)$/[$(printf '%s' $currDateTime) #$(printf '%03X\n' $BASHPID).??? $(printf '%-5s' '\U\1\E') -            -   ] ${script##*/}: \2/"
+        "$script" |& sed -ure "s/^warning:/WARN:/I; /^(info|error|warn|debug|trace):/I!s/^/info: /; s/^(\w{0,4}):/\1 :/I; s/^([^:]*): ?(.*)$/[$(printf '%s' $currDateTime) #$(printf '%03X\n' $BASHPID).??? \U\1\E -            -   ] ${script##*/}: \2/"
     fi
 done
 

--- a/src/main/docker/startup/startup.sh
+++ b/src/main/docker/startup/startup.sh
@@ -25,7 +25,7 @@ log "Running startup scripts..."
 for script in $(dirname "$0")/startup.d/*; do
     if [ -x "$script" ]; then
         log "Running ${script##*/}..."
-        "$script" |& sed -ure "/^(info|error|warn|debug|trace|INFO|ERROR|WARN|DEBUG|TRACE):/!s/^/info: /I; s/^(([^:]*): ?)?(.*)$/[$(date +%H:%M:%S.%3NZ) #$(printf '%03X\n' $BASHPID).??? $(printf '%s\n' '\U\2\E')  -            - ]  ${script##*/}: \3/I"
+        "$script" |& sed -ure "/^(info|error|warn|debug|trace|INFO|ERROR|WARN|DEBUG|TRACE):/!s/^/info: /I; s/^(([^:]*): ?)?(.*)$/[$(date +%H:%M:%S.%3NZ) #$(printf '%03X\n' $BASHPID).??? $(printf '%s\n' '\U\2\E') -            -   ] ${script##*/}: \3/I"
     fi
 done
 

--- a/src/main/docker/startup/startup.sh
+++ b/src/main/docker/startup/startup.sh
@@ -17,7 +17,7 @@
 
 # Create a convenience function for logging
 log() {
-    echo "[$(date +%H:%M:%S.%3NZ) #$(printf '%03X\n' $$).??? INFO -            -   ] ${0##*/}: $@"
+    echo "[$(date +%H:%M:%S.%3NZ) #$(printf '%03X\n' $$).??? INFO  -            -   ] ${0##*/}: $@"
 }
 
 # Run the executable scripts that are in the drop-in folder
@@ -25,7 +25,7 @@ log "Running startup scripts..."
 for script in $(dirname "$0")/startup.d/*; do
     if [ -x "$script" ]; then
         log "Running ${script##*/}..."
-        "$script" |& sed -ure "s/^warning:/WARN:/I; /^(info|error|warn|debug|trace):/I!s/^/info: /; s/^([^:]*): ?(.*)$/[$(date +%H:%M:%S.%3NZ) #$(printf '%03X\n' $BASHPID).??? \U\1\E -            -   ] ${script##*/}: \2/"
+        "$script" |& sed -ure "s/^warning:/WARN :/I; /^(info|error|warn|debug|trace):/I!s/^/info : /; s/^([^ :]*): ?(.*)$/[$(date +%H:%M:%S.%3NZ) #$(printf '%03X\n' $BASHPID).??? $(printf  '%-5s\n' '\U\1\E' ) -            -   ] ${script##*/}: \2/"
     fi
 done
 

--- a/src/main/docker/startup/startup.sh
+++ b/src/main/docker/startup/startup.sh
@@ -26,7 +26,11 @@ for script in $(dirname "$0")/startup.d/*; do
     if [ -x "$script" ]; then
         log "Running ${script##*/}..."
         currDateTime=$(date +%H:%M:%S.%3NZ)
-        "$script" |& sed -ure "s/^warning:/WARN:/I; /^(info|error|warn|debug|trace):/I!s/^/info: /; s/^(\w{0,4}):/\1 :/I; s/^([^:]*): ?(.*)$/[$(printf '%s' $currDateTime) #$(printf '%03X\n' $BASHPID).??? \U\1\E -            -   ] ${script##*/}: \2/"
+        "$script" |& sed -ure "
+            s/^warning:/WARN:/I;
+            /^(info|error|warn|debug|trace):/I!s/^/info: /;
+            s/^(\w{0,4}):/\1 :/I;
+            s/^([^:]*): ?(.*)$/[$(printf '%s' $currDateTime) #$(printf '%03X\n' $BASHPID).??? \U\1\E -            -   ] ${script##*/}: \2/"
     fi
 done
 

--- a/src/main/docker/startup/startup.sh
+++ b/src/main/docker/startup/startup.sh
@@ -25,7 +25,7 @@ log "Running startup scripts..."
 for script in $(dirname "$0")/startup.d/*; do
     if [ -x "$script" ]; then
         log "Running ${script##*/}..."
-        "$script" |& sed -ure "/^(info|error|warn|debug|trace|INFO|ERROR|WARN|DEBUG|TRACE):/!s/^/info: /I; s/^(([^:]*): ?)?(.*)$/[$(date +%H:%M:%S.%3NZ) #$(printf '%03X\n' $BASHPID).??? $(printf '%s\n' '\U\2\E') -            -   ] ${script##*/}: \3/I"
+        "$script" |& sed -ure "/^(info|error|warn|debug|trace|INFO|ERROR|WARN|DEBUG|TRACE):/!s/^/info: /I; s/^(([^:]*): ?)?(.*)$/[$(date +%H:%M:%S.%3NZ) #$(printf '%03X\n' $BASHPID).??? \U\2\E -            -   ] ${script##*/}: \3/I"
     fi
 done
 

--- a/src/main/docker/startup/startup.sh
+++ b/src/main/docker/startup/startup.sh
@@ -25,7 +25,8 @@ log "Running startup scripts..."
 for script in $(dirname "$0")/startup.d/*; do
     if [ -x "$script" ]; then
         log "Running ${script##*/}..."
-        "$script" |& sed -ure "s/^warning:/WARN :/I; /^(info|error|warn|debug|trace):/I!s/^/info : /; s/^([^ :]*): ?(.*)$/[$(date +%H:%M:%S.%3NZ) #$(printf '%03X\n' $BASHPID).??? $(printf  '%-5s\n' '\U\1\E' ) -            -   ] ${script##*/}: \2/"
+        currDateTime=$(date +%H:%M:%S.%3NZ)
+        "$script" |& sed -ure "s/^warning:/WARN:/I; /^(info|error|warn|debug|trace):/I!s/^/info: /; s/^([^:]*): ?(.*)$/[$(printf '%s' $currDateTime) #$(printf '%03X\n' $BASHPID).??? $(printf '%-5s' '\U\1\E') -            -   ] ${script##*/}: \2/"
     fi
 done
 

--- a/src/main/docker/startup/startup.sh
+++ b/src/main/docker/startup/startup.sh
@@ -25,7 +25,7 @@ log "Running startup scripts..."
 for script in $(dirname "$0")/startup.d/*; do
     if [ -x "$script" ]; then
         log "Running ${script##*/}..."
-        "$script" |& sed -ure "s/^((info|error|warn|debug|trace): ?)?(.*)$/[$(date +%H:%M:%S.%3NZ) #$(printf '%03X\n' $BASHPID).??? $(printf '%s\n' '\U\2\E')  -            - ]  ${script##*/}: \3/I"
+        "$script" |& sed -ure "/^(info|error|warn|debug|trace|INFO|ERROR|WARN|DEBUG|TRACE):/!s/^/info: /I; s/^(([^:]*): ?)?(.*)$/[$(date +%H:%M:%S.%3NZ) #$(printf '%03X\n' $BASHPID).??? $(printf '%s\n' '\U\2\E')  -            - ]  ${script##*/}: \3/I"
     fi
 done
 

--- a/src/main/docker/startup/startup.sh
+++ b/src/main/docker/startup/startup.sh
@@ -17,7 +17,7 @@
 
 # Create a convenience function for logging
 log() {
-    echo "${0##*/}: $@"
+    echo "[$(date +%H:%M:%S.%3NZ) #$(printf '%03X\n' $BASHPID).??? INFO -            -   ] ${0##*/}: $@"
 }
 
 # Run the executable scripts that are in the drop-in folder
@@ -25,7 +25,7 @@ log "Running startup scripts..."
 for script in $(dirname "$0")/startup.d/*; do
     if [ -x "$script" ]; then
         log "Running ${script##*/}..."
-        "$script" |& sed -ure "/^(info|error|warn|debug|trace|INFO|ERROR|WARN|DEBUG|TRACE):/!s/^/info: /I; s/^(([^:]*): ?)?(.*)$/[$(date +%H:%M:%S.%3NZ) #$(printf '%03X\n' $BASHPID).??? \U\2\E -            -   ] ${script##*/}: \3/I"
+        "$script" |& sed -ure "s/^warning:/WARN:/I; /^(info|error|warn|debug|trace|INFO|ERROR|WARN|DEBUG|TRACE):/!s/^/info: /I; s/^([^:]*): ?(.*)$/[$(date +%H:%M:%S.%3NZ) #$(printf '%03X\n' $BASHPID).??? \U\1\E -            -   ] ${script##*/}: \2/I"
     fi
 done
 

--- a/src/main/docker/startup/startup.sh
+++ b/src/main/docker/startup/startup.sh
@@ -25,7 +25,7 @@ log "Running startup scripts..."
 for script in $(dirname "$0")/startup.d/*; do
     if [ -x "$script" ]; then
         log "Running ${script##*/}..."
-        "$script" |& sed -ure "s/^warning:/WARN:/I; /^(info|error|warn|debug|trace|INFO|ERROR|WARN|DEBUG|TRACE):/!s/^/info: /I; s/^([^:]*): ?(.*)$/[$(date +%H:%M:%S.%3NZ) #$(printf '%03X\n' $BASHPID).??? \U\1\E -            -   ] ${script##*/}: \2/I"
+        "$script" |& sed -ure "s/^warning:/WARN:/I; /^(info|error|warn|debug|trace):/I!s/^/info: /; s/^([^:]*): ?(.*)$/[$(date +%H:%M:%S.%3NZ) #$(printf '%03X\n' $BASHPID).??? \U\1\E -            -   ] ${script##*/}: \2/I"
     fi
 done
 

--- a/src/main/docker/startup/startup.sh
+++ b/src/main/docker/startup/startup.sh
@@ -25,7 +25,7 @@ log "Running startup scripts..."
 for script in $(dirname "$0")/startup.d/*; do
     if [ -x "$script" ]; then
         log "Running ${script##*/}..."
-        "$script" |& sed -ure "s/^((info|error|warn|debug|trace): ?)?(.*)$/[$(date +%H:%M:%S.%3NZ) #$(printf '%03X\n' "$BASHPID").??? $(printf '%s\n' '\U\2\E')  -            - ]  ${script##*/}: \3/I"
+        "$script" |& sed -ure "s/^((info|error|warn|debug|trace): ?)?(.*)$/[$(date +%H:%M:%S.%3NZ) #$(printf '%03X\n' $BASHPID).??? $(printf '%s\n' '\U\2\E')  -            - ]  ${script##*/}: \3/I"
     fi
 done
 


### PR DESCRIPTION
https://portal.digitalsafe.net/browse/SCMOD-7472

http://sou-jenkins2.hpeswlab.net/job/CAFapi/job/CAFapi~opensuse-base-image~SCMOD-7472~CI/

The latest startup scripts log output from worker-elastic is
[21:41:41.544Z #00D.??? INFO -            -   ] install-ca-cert-base.sh: Not installing CA Certificate.
The caf-logging format
[10:50:25.465Z #bff.009 DEBUG acme-corp    -   ] com.github.example.Logger: Example Log Message

worker-elastic build using latest opensuse-jre image

https://jenkins.swinfra.net/job/SEPG/job/caf/view/Developer/job/caf~worker-elastic~SCMOD-7472~CI/

https://github.houston.softwaregrp.net/caf/worker-elastic/compare/SCMOD-7472