### PR TITLE
SCMOD-6665: Add locale, update tini

### DIFF
--- a/release-notes-1.3.0.md
+++ b/release-notes-1.3.0.md
@@ -4,6 +4,7 @@
 ${version-number}
 
 #### New Features
-- [SCMOD-6665](https://portal.digitalsafe.net/browse/SCMOD-6665): Add locale setting, update tini version
+- [SCMOD-6665](https://portal.digitalsafe.net/browse/SCMOD-6665): Add locale setting, update tini version to [v0.18.0](https://github.com/krallin/tini/releases/tag/v0.18.0)
 
 #### Known Issues
+- None

--- a/release-notes-1.3.0.md
+++ b/release-notes-1.3.0.md
@@ -4,5 +4,5 @@
 ${version-number}
 
 #### New Features
-
+- [SCMOD-6665]: Add locale setting, update tini version, update copyright date
 #### Known Issues

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2018 Micro Focus or one of its affiliates.
+# Copyright 2017-2019 Micro Focus or one of its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,6 +16,9 @@
 
 FROM opensuse/leap:latest
 
+# Set the locale manually to a set inherited from the base image (defaults to POSIX)
+ENV LANG=en_US.utf8
+
 # Update the OS packages, install cURL and postgreSQL client
 RUN zypper -n refresh && \
     zypper -n update && \
@@ -28,7 +31,7 @@ ADD https://raw.githubusercontent.com/CAFapi/caf-common/v1.14.0/container-cert-s
 RUN chmod +x /startup/* /startup/startup.d/*
 
 # Add Tini
-ENV TINI_VERSION v0.16.1
+ENV TINI_VERSION v0.18.0
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
 RUN chmod +x /tini
 ENTRYPOINT ["/tini", "--", "/startup/startup.sh"]


### PR DESCRIPTION
Add explicit locale setting (locale constrcuted in opensuse/leap, but not properly set)
Update copyright
Update to current tini version.  (was from 2017, current is apr. 2018)

Basic testing against raw dockerfile for successful build and handling of files with foreign characters.