### PR TITLE
Run zypper clean after installing packages to reduce image size

### DIFF
--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -23,7 +23,8 @@ ENV LANG=en_US.utf8
 # Update the OS packages, install cURL and postgreSQL client
 RUN zypper -n refresh && \
     zypper -n update && \
-    zypper -n install curl postgresql dejavu-fonts
+    zypper -n install curl postgresql dejavu-fonts && \
+    zypper -n clean --all
 
 # Add scripts to be executed during startup
 COPY startup /startup


### PR DESCRIPTION
Running zypper clean after installing packages reduces the final image size by about 76MB bringing the final image size to 180MB. The only possible impact of this is that derived images may take slightly longer to build because the zypper cache is not already primed from the base image. Of course to realize the space savings in the final derived image, similar changes would need to be made in other intermediate container images or else the cache will just be added back in by the next container image that does a zypper update. I'm willing to submit pull requests for other base images if this one is accepted.