### PR TITLE
SCMOD-11949: Add gosu to base image

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This project builds an openSUSE-based image intended for use as a general servic
 [DejaVu Fonts](https://dejavu-fonts.github.io/) is pre-installed in the container. The DejaVu fonts are a font family based on the Bitstream Vera Fonts. Its purpose is to provide a wider range of characters while maintaining the original look and feel through the process of collaborative development.
 
 ### Gosu
-[gosu](https://github.com/tianon/gosu/) is pre-installed in the container. Gosu allows derived images to run commands as a specified user, rather than as the default user.  
+[Gosu](https://github.com/tianon/gosu/) is pre-installed in the container. Gosu allows derived images to run commands as a specified user, rather than as the default user.  
 
 To use gosu, set the RUNAS_USER environment variable in the derived container's Dockerfile, prior to any `CMD` instruction, and that `CMD` instruction will then be run as the specified user:
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This project builds an openSUSE-based image intended for use as a general servic
 ### Gosu
 [Gosu](https://github.com/tianon/gosu/) is pre-installed in the container. Gosu allows derived images to run commands as a specified user, rather than as the default user.  
 
-To use gosu, set the RUNAS_USER environment variable in the derived container's Dockerfile, prior to any `CMD` instruction, and that `CMD` instruction will then be run as the specified user:
+To use gosu, set the `RUNAS_USER` environment variable in the derived container's Dockerfile, prior to any `CMD` instruction, and that `CMD` instruction will then be run as the specified user:
 
 ```
 RUNAS_USER=my-user

--- a/README.md
+++ b/README.md
@@ -11,6 +11,18 @@ This project builds an openSUSE-based image intended for use as a general servic
 ### DejaVu Fonts
 [DejaVu Fonts](https://dejavu-fonts.github.io/) is pre-installed in the container. The DejaVu fonts are a font family based on the Bitstream Vera Fonts. Its purpose is to provide a wider range of characters while maintaining the original look and feel through the process of collaborative development.
 
+### Gosu
+[gosu](https://github.com/tianon/gosu/) is pre-installed in the container. Gosu allows derived images to run commands as a specified user, rather than as the default user.  
+
+To use gosu, set the RUNAS_USER environment variable in the derived container's Dockerfile, prior to any `CMD` instruction, and that `CMD` instruction will then be run as the specified user:
+
+```
+RUNAS_USER=my-user
+CMD ["whoami"] # Outputs my-user
+```
+
+Note: the user specified by the `RUNAS_USER` is expected to already exist, and the `CMD` will fail if this is not the case.
+
 ### Startup Scripts
 Any executable scripts added to the `/startup/startup.d/` directory will be automatically run each time the container is started (assuming the image entrypoint is not overwritten).
 

--- a/release-notes-2.3.0.md
+++ b/release-notes-2.3.0.md
@@ -4,5 +4,9 @@
 ${version-number}
 
 #### New Features
+- SCMOD-11949: The [gosu](https://github.com/tianon/gosu/) tool is now available in the base image.  
+  This tool allows derived images to run commands as a specified user, rather than as the default user.  
+  See the [README.md])https://github.com/CAFapi/opensuse-base-image/blob/develop/README.md) for more details.
 
 #### Known Issues
+- None

--- a/release-notes-2.3.0.md
+++ b/release-notes-2.3.0.md
@@ -6,7 +6,7 @@ ${version-number}
 #### New Features
 - SCMOD-11949: The [gosu](https://github.com/tianon/gosu/) tool is now available in the base image.  
   This tool allows derived images to run commands as a specified user, rather than as the default user.  
-  See the [README.md])https://github.com/CAFapi/opensuse-base-image/blob/develop/README.md) for more details.
+  See the [README.md](https://github.com/CAFapi/opensuse-base-image/blob/develop/README.md) for more details.
 
 #### Known Issues
 - None

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -27,12 +27,20 @@ RUN zypper -n refresh && \
     zypper -n clean --all
 
 # Install gosu
-RUN    gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
-    && curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.10/gosu-amd64" \
-    && curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.10/gosu-amd64.asc" \
-    && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
-    && rm /usr/local/bin/gosu.asc \
-    && chmod +x /usr/local/bin/gosu
+#RUN    gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+#    && curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.10/gosu-amd64" \
+#    && curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.10/gosu-amd64.asc" \
+#    && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
+#    && rm /usr/local/bin/gosu.asc \
+#    && chmod +x /usr/local/bin/gosu
+
+# Temp split out of RUN cmd to investigate jenkins build failures
+RUN gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
+RUN curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.10/gosu-amd64"
+RUN curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.10/gosu-amd64.asc"
+RUN gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu
+RUN rm /usr/local/bin/gosu.asc
+RUN chmod +x /usr/local/bin/gosu
 
 # Add scripts to be executed during startup
 COPY startup /startup

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -26,6 +26,14 @@ RUN zypper -n refresh && \
     zypper -n install curl postgresql dejavu-fonts && \
     zypper -n clean --all
 
+# Install gosu
+RUN    gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+    && curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.10/gosu-amd64" \
+    && curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.10/gosu-amd64.asc" \
+    && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
+    && rm /usr/local/bin/gosu.asc \
+    && chmod +x /usr/local/bin/gosu
+
 # Add scripts to be executed during startup
 COPY startup /startup
 ADD https://raw.githubusercontent.com/CAFapi/caf-common/v1.19.0/container-cert-script/install-ca-cert.sh \

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -35,7 +35,7 @@ RUN zypper -n refresh && \
 #    && chmod +x /usr/local/bin/gosu
 
 # Temp split out of RUN cmd to investigate jenkins build failures
-RUN gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
+RUN gpg --batch --keyserver-options http_proxy=http://web-proxy.uk.softwaregrp.net:8080 --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
 RUN curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.10/gosu-amd64"
 RUN curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.10/gosu-amd64.asc"
 RUN gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -35,7 +35,7 @@ RUN zypper -n refresh && \
 #    && chmod +x /usr/local/bin/gosu
 
 # Temp split out of RUN cmd to investigate jenkins build failures
-RUN gpg --batch --keyserver-options http_proxy=http://web-proxy.uk.softwaregrp.net:8080 --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
+RUN gpg --batch --keyserver-options http_proxy=http://web-proxy.uk.softwaregrp.net:8080 https_proxy=http://web-proxy.uk.softwaregrp.net:8080 --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
 RUN curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.10/gosu-amd64"
 RUN curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.10/gosu-amd64.asc"
 RUN gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu

--- a/src/main/docker/startup/startup.sh
+++ b/src/main/docker/startup/startup.sh
@@ -36,5 +36,13 @@ done
 
 log "Startup scripts completed"
 
-# Execute the specified command
-exec "$@"
+# If the RUNAS_USER environment variable is set, execute the specified command as that user.
+if [ -n "$RUNAS_USER" ]; then
+    log "The RUNAS_USER environment variable has been set with a user named ${RUNAS_USER}. \
+Subsequent commands will be run as this user. \
+Please note that this user is expected to already exist, and will not be created."
+    exec /usr/local/bin/gosu $RUNAS_USER "$@"
+else
+    log "The RUNAS_USER environment variable is not set, subsequent commands will be run as the default user."
+    exec "$@"
+fi


### PR DESCRIPTION
Adding [gosu](https://github.com/tianon/gosu/) to the base image. Gosu allows derived images to run commands as a specified user, rather than as the default user.  

To use gosu, set the `RUNAS_USER` environment variable in the derived container's Dockerfile, prior to any `CMD` instruction, and that `CMD` instruction will then be run as the specified user:

```
RUNAS_USER=my-user
CMD ["whoami"] # Outputs my-user
```

Note: the user specified by the `RUNAS_USER` is expected to already exist, and the `CMD` will fail if this is not the case.