### PR TITLE
SCMOD-13948:  Using opensuse:latest (15.3) requires dirmngr package in builder image to install gosu

### DIFF
--- a/release-notes-2.4.0.md
+++ b/release-notes-2.4.0.md
@@ -4,5 +4,6 @@
 ${version-number}
 
 #### New Features
+- SCMOD-13948: dirmngr package is required when using latest opensuse-leap 15.3.
 
 #### Known Issues

--- a/release-notes-2.4.0.md
+++ b/release-notes-2.4.0.md
@@ -4,6 +4,7 @@
 ${version-number}
 
 #### New Features
-- SCMOD-13948: dirmngr package is required when using latest opensuse-leap 15.3.
+- The base image is now based on openSUSE Leap 15.3. 
+The release notes for openSUSE Leap 15.3 can be found [here](https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/15.3/)..
 
 #### Known Issues

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -14,21 +14,28 @@
 # limitations under the License.
 #
 
+# Docker registry
 ARG DOCKER_HUB_PUBLIC=docker.io
 
 #
 # Preliminary image to prepare the gosu package since opensuse leap 15.3
 # no longer contains the required dirmngr package.
 #
-FROM ${DOCKER_HUB_PUBLIC}/opensuse/leap:latest as builder
+FROM ${DOCKER_HUB_PUBLIC}/opensuse/leap:latest AS builder
 
-# Update the OS packages with dirmngr and curl to enable gosu install
+# Set the locale manually to a set inherited from the base image (defaults to POSIX)
+ENV LANG=en_US.utf8
+
+# Update the OS packages, install cURL, postgreSQL client and dejavu-fonts
 RUN zypper -n refresh && \
     zypper -n update && \
-    zypper -n install dirmngr curl && \
+    zypper -n install curl postgresql dejavu-fonts && \
     zypper -n clean --all
 
-# Install gosu
+# Install dirmngr to enable gosu verification
+RUN zypper -n install dirmngr
+
+# Download and verify gosu
 RUN gpg --batch --keyserver-options http-proxy=${env.HTTP_PROXY} --keyserver hkps://keys.openpgp.org \
       --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 && \
     curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.12/gosu-amd64" && \

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -36,10 +36,10 @@ FROM ${DOCKER_HUB_PUBLIC}/opensuse/leap:latest
 # Set the locale manually to a set inherited from the base image (defaults to POSIX)
 ENV LANG=en_US.utf8
 
-# Update the OS packages, install postgreSQL client and dejavu-fonts
+# Update the OS packages, install cURL, postgreSQL client and dejavu-fonts
 RUN zypper -n refresh && \
     zypper -n update && \
-    zypper -n install postgresql dejavu-fonts && \
+    zypper -n install curl postgresql dejavu-fonts && \
     zypper -n clean --all
 
 # Copy gosu

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -15,15 +15,12 @@
 #
 
 ARG DOCKER_HUB_PUBLIC=docker.io
-FROM ${DOCKER_HUB_PUBLIC}/opensuse/leap:latest
+FROM ${DOCKER_HUB_PUBLIC}/opensuse/leap:latest as builder
 
-# Set the locale manually to a set inherited from the base image (defaults to POSIX)
-ENV LANG=en_US.utf8
-
-# Update the OS packages, install cURL, postgreSQL client and dejavu-fonts
+# Update the OS packages with dirmngr and curl to enable gosu install
 RUN zypper -n refresh && \
     zypper -n update && \
-    zypper -n install dirmngr curl postgresql dejavu-fonts && \
+    zypper -n install dirmngr curl && \
     zypper -n clean --all
 
 # Install gosu
@@ -31,9 +28,23 @@ RUN gpg --batch --keyserver-options http-proxy=${env.HTTP_PROXY} --keyserver hkp
       --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 && \
     curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.12/gosu-amd64" && \
     curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.12/gosu-amd64.asc" && \
-    gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu && \
-    rm /usr/local/bin/gosu.asc && \
-    chmod +x /usr/local/bin/gosu
+    gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu
+
+ARG DOCKER_HUB_PUBLIC
+FROM ${DOCKER_HUB_PUBLIC}/opensuse/leap:latest
+
+# Set the locale manually to a set inherited from the base image (defaults to POSIX)
+ENV LANG=en_US.utf8
+
+# Update the OS packages, install postgreSQL client and dejavu-fonts
+RUN zypper -n refresh && \
+    zypper -n update && \
+    zypper -n install postgresql dejavu-fonts && \
+    zypper -n clean --all
+
+# Copy gosu
+COPY --from=builder /usr/local/bin/gosu /usr/local/bin/gosu
+RUN chmod +x /usr/local/bin/gosu
 
 # Add scripts to be executed during startup
 COPY startup /startup

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -23,7 +23,7 @@ ENV LANG=en_US.utf8
 # Update the OS packages, install cURL, postgreSQL client and dejavu-fonts
 RUN zypper -n refresh && \
     zypper -n update && \
-    zypper -n install curl postgresql dejavu-fonts && \
+    zypper -n install dirmngr curl postgresql dejavu-fonts && \
     zypper -n clean --all
 
 # Install gosu

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -14,11 +14,12 @@
 # limitations under the License.
 #
 
+ARG DOCKER_HUB_PUBLIC=docker.io
+
 #
 # Preliminary image to prepare the gosu package since opensuse leap 15.3
 # no longer contains the required dirmngr package.
 #
-ARG DOCKER_HUB_PUBLIC=docker.io
 FROM ${DOCKER_HUB_PUBLIC}/opensuse/leap:latest as builder
 
 # Update the OS packages with dirmngr and curl to enable gosu install

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -14,6 +14,10 @@
 # limitations under the License.
 #
 
+#
+# Preliminary image to prepare the gosu package since opensuse leap 15.3
+# no longer contains the required dirmngr package.
+#
 ARG DOCKER_HUB_PUBLIC=docker.io
 FROM ${DOCKER_HUB_PUBLIC}/opensuse/leap:latest as builder
 
@@ -28,9 +32,12 @@ RUN gpg --batch --keyserver-options http-proxy=${env.HTTP_PROXY} --keyserver hkp
       --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 && \
     curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.12/gosu-amd64" && \
     curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.12/gosu-amd64.asc" && \
-    gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu
+    gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu && \
+    chmod +x /usr/local/bin/gosu
 
-ARG DOCKER_HUB_PUBLIC
+#
+# The actual image definition
+#
 FROM ${DOCKER_HUB_PUBLIC}/opensuse/leap:latest
 
 # Set the locale manually to a set inherited from the base image (defaults to POSIX)
@@ -44,7 +51,6 @@ RUN zypper -n refresh && \
 
 # Copy gosu
 COPY --from=builder /usr/local/bin/gosu /usr/local/bin/gosu
-RUN chmod +x /usr/local/bin/gosu
 
 # Add scripts to be executed during startup
 COPY startup /startup


### PR DESCRIPTION
https://portal.digitalsafe.net/browse/SCMOD-13948