### PR TITLE
US478076: Tini upgraded to v0.19.0

### DIFF
--- a/release-notes-2.5.0.md
+++ b/release-notes-2.5.0.md
@@ -6,5 +6,6 @@ ${version-number}
 #### New Features
 - The base image is now based on [openSUSE Leap 15.4](https://en.opensuse.org/Portal:15.4).  
 The release notes for openSUSE Leap 15.4 can be found [here](https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/15.4/).
+- US478076: Tini has been upgraded to [v0.19.0](https://github.com/krallin/tini/releases/tag/v0.19.0).
 
 #### Known Issues

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -67,7 +67,7 @@ ADD https://raw.githubusercontent.com/CAFapi/caf-common/v1.19.0/container-cert-s
 RUN chmod +x /startup/* /startup/startup.d/*
 
 # Add Tini
-ENV TINI_VERSION v0.18.0
+ENV TINI_VERSION v0.19.0
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
 RUN chmod +x /tini
 ENTRYPOINT ["/tini", "--", "/startup/startup.sh"]


### PR DESCRIPTION
https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=478076