### PR TITLE
US369215: Disable weaker security algorithms

### DIFF
--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -75,7 +75,7 @@ ENTRYPOINT ["/tini", "--", "/startup/startup.sh"]
 # Install crypto-policies-scripts and disable weaker security algorithms
 RUN zypper -n install crypto-policies-scripts && \
     update-crypto-policies --set FUTURE && \
-	zypper -n remove -u crypto-policies-scripts
+    zypper -n remove -u crypto-policies-scripts
 
 # Add other useful scripts
 COPY scripts /scripts

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -72,6 +72,11 @@ ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
 RUN chmod +x /tini
 ENTRYPOINT ["/tini", "--", "/startup/startup.sh"]
 
+# Install crypto-policies-scripts and disable weaker security algorithms
+RUN zypper -n install crypto-policies-scripts && \
+    update-crypto-policies --set FUTURE && \
+	zypper -n remove -u crypto-policies-scripts
+
 # Add other useful scripts
 COPY scripts /scripts
 RUN chmod +x /scripts/*

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -55,8 +55,7 @@ ENV LANG=en_US.utf8
 # Install crypto-policies-scripts and disable weaker security algorithms
 RUN zypper -n refresh && \
     zypper -n update && \
-    zypper -n install curl postgresql dejavu-fonts && \
-    zypper -n install crypto-policies-scripts && \
+    zypper -n install curl postgresql dejavu-fonts crypto-policies-scripts && \
     update-crypto-policies --set FUTURE && \
     zypper -n remove -u crypto-policies-scripts && \
     zypper -n clean --all

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -52,9 +52,13 @@ FROM ${DOCKER_HUB_PUBLIC}/opensuse/leap:latest
 ENV LANG=en_US.utf8
 
 # Update the OS packages, install cURL, postgreSQL client and dejavu-fonts
+# Install crypto-policies-scripts and disable weaker security algorithms
 RUN zypper -n refresh && \
     zypper -n update && \
     zypper -n install curl postgresql dejavu-fonts && \
+    zypper -n install crypto-policies-scripts && \
+    update-crypto-policies --set FUTURE && \
+    zypper -n remove -u crypto-policies-scripts && \
     zypper -n clean --all
 
 # Copy gosu
@@ -71,11 +75,6 @@ ENV TINI_VERSION v0.19.0
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
 RUN chmod +x /tini
 ENTRYPOINT ["/tini", "--", "/startup/startup.sh"]
-
-# Install crypto-policies-scripts and disable weaker security algorithms
-RUN zypper -n install crypto-policies-scripts && \
-    update-crypto-policies --set FUTURE && \
-    zypper -n remove -u crypto-policies-scripts
 
 # Add other useful scripts
 COPY scripts /scripts


### PR DESCRIPTION
https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=369215

Disable weaker security algorithms by updating system wide crypto-policies
Refer: https://en.opensuse.org/SDB:Crypto-policies