### PR TITLE
US369215: Disable TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256 cipher

### DIFF
--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -60,7 +60,8 @@ RUN zypper -n refresh && \
     zypper -n update && \
     zypper -n install curl postgresql dejavu-fonts crypto-policies-scripts && \
     update-crypto-policies --set DEFAULT:DISABLE-CBC && \
-    sed -rie '/^jdk.tls.disabledAlgorithms=/s/$/, TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256/' /etc/crypto-policies/back-ends/java.config && \
+    sed -rie /^jdk.tls.disabledAlgorithms=/s/$/, TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256/' \
+    /etc/crypto-policies/back-ends/java.config && \
     zypper -n remove -u crypto-policies-scripts && \
     zypper -n clean --all
 

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -60,6 +60,7 @@ RUN zypper -n refresh && \
     zypper -n update && \
     zypper -n install curl postgresql dejavu-fonts crypto-policies-scripts && \
     update-crypto-policies --set DEFAULT:DISABLE-CBC && \
+    sed -rie '/^jdk.tls.disabledAlgorithms=/s/$/, TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256/' /etc/crypto-policies/back-ends/java.config
     zypper -n remove -u crypto-policies-scripts && \
     zypper -n clean --all
 

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -60,8 +60,8 @@ RUN zypper -n refresh && \
     zypper -n update && \
     zypper -n install curl postgresql dejavu-fonts crypto-policies-scripts && \
     update-crypto-policies --set DEFAULT:DISABLE-CBC && \
-    sed -rie /^jdk.tls.disabledAlgorithms=/s/$/, TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256/' \
-    /etc/crypto-policies/back-ends/java.config && \
+    sed -rie '/^jdk.tls.disabledAlgorithms=/s/$/, TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256/' \
+        /etc/crypto-policies/back-ends/java.config && \
     zypper -n remove -u crypto-policies-scripts && \
     zypper -n clean --all
 

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -60,7 +60,7 @@ RUN zypper -n refresh && \
     zypper -n update && \
     zypper -n install curl postgresql dejavu-fonts crypto-policies-scripts && \
     update-crypto-policies --set DEFAULT:DISABLE-CBC && \
-    sed -rie '/^jdk.tls.disabledAlgorithms=/s/$/, TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256/' /etc/crypto-policies/back-ends/java.config \
+    sed -rie '/^jdk.tls.disabledAlgorithms=/s/$/, TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256/' /etc/crypto-policies/back-ends/java.config && \
     zypper -n remove -u crypto-policies-scripts && \
     zypper -n clean --all
 

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -60,7 +60,7 @@ RUN zypper -n refresh && \
     zypper -n update && \
     zypper -n install curl postgresql dejavu-fonts crypto-policies-scripts && \
     update-crypto-policies --set DEFAULT:DISABLE-CBC && \
-    sed -rie '/^jdk.tls.disabledAlgorithms=/s/$/, TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256/' /etc/crypto-policies/back-ends/java.config
+    sed -rie '/^jdk.tls.disabledAlgorithms=/s/$/, TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256/' /etc/crypto-policies/back-ends/java.config \
     zypper -n remove -u crypto-policies-scripts && \
     zypper -n clean --all
 


### PR DESCRIPTION
https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=369215
TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256 is not listed in the 'Intermediate compatibility' list here: https://wiki.mozilla.org/Security/Cipher_Suites.

There is no mapping for the 'CHACHA20-POLY1305' cipher for the java config and hence it is not possible to disable the cipher in the custom crypto policy.
Refer: https://gitlab.com/redhat-crypto/fedora-crypto-policies/-/blob/master/python/policygenerators/java.py#L32
Modifying the generated java policy config file to add the cipher to the disabledAlgorithms list.