### PR TITLE
US369215: Use crypto policy when downloading and verifing gosu

### DIFF
--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -18,35 +18,11 @@
 ARG DOCKER_HUB_PUBLIC=docker.io
 
 #
-# Preliminary image to prepare the gosu package since opensuse leap 15.3
-# no longer contains the required dirmngr package.
+# Stage 1: The start of the actual image definition
+# - Install desired packages
+# - Specify policy for cryptographic back-ends
 #
-FROM ${DOCKER_HUB_PUBLIC}/opensuse/leap:latest AS builder
-
-# Set the locale manually to a set inherited from the base image (defaults to POSIX)
-ENV LANG=en_US.utf8
-
-# Update the OS packages, install cURL, postgreSQL client and dejavu-fonts
-RUN zypper -n refresh && \
-    zypper -n update && \
-    zypper -n install curl postgresql dejavu-fonts && \
-    zypper -n clean --all
-
-# Install dirmngr to enable gosu verification
-RUN zypper -n install dirmngr
-
-# Download and verify gosu
-RUN gpg --batch --keyserver-options http-proxy=${env.HTTP_PROXY} --keyserver hkps://keys.openpgp.org \
-        --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 && \
-    curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.14/gosu-amd64" && \
-    curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.14/gosu-amd64.asc" && \
-    gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu && \
-    chmod +x /usr/local/bin/gosu
-
-#
-# The actual image definition
-#
-FROM ${DOCKER_HUB_PUBLIC}/opensuse/leap:latest
+FROM ${DOCKER_HUB_PUBLIC}/opensuse/leap:latest AS stage1
 
 # Set the locale manually to a set inherited from the base image (defaults to POSIX)
 ENV LANG=en_US.utf8
@@ -65,8 +41,29 @@ RUN zypper -n refresh && \
     zypper -n remove -u crypto-policies-scripts && \
     zypper -n clean --all
 
+#
+# Stage 2: Download and verify gosu
+#
+FROM stage1 AS stage2
+
+# Install dirmngr to enable gosu verification
+RUN zypper -n install dirmngr
+
+# Download and verify gosu
+RUN gpg --batch --keyserver-options http-proxy=${env.HTTP_PROXY} --keyserver hkps://keys.openpgp.org \
+        --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 && \
+    curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.14/gosu-amd64" && \
+    curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.14/gosu-amd64.asc" && \
+    gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu && \
+    chmod +x /usr/local/bin/gosu
+
+#
+# Stage 3: The remainder of the actual image definition
+#
+FROM stage1
+
 # Copy gosu
-COPY --from=builder /usr/local/bin/gosu /usr/local/bin/gosu
+COPY --from=stage2 /usr/local/bin/gosu /usr/local/bin/gosu
 
 # Add scripts to be executed during startup
 COPY startup /startup


### PR DESCRIPTION
https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=369215

Currently the gosu package is being downloaded before the application of the cryptographic policies.
I've re-ordered the file so that this is not the case.

This should also improve performance slightly be re-using image layers better.