### PR TITLE
477072: Move to opensuse/tumbleweed:latest

### DIFF
--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -22,7 +22,7 @@ ARG DOCKER_HUB_PUBLIC=docker.io
 # - Install desired packages
 # - Specify policy for cryptographic back-ends
 #
-FROM ${DOCKER_HUB_PUBLIC}/opensuse/leap:latest AS stage1
+FROM ${DOCKER_HUB_PUBLIC}/opensuse/tumbleweed:latest AS stage1
 
 # Set the locale manually to a set inherited from the base image (defaults to POSIX)
 ENV LANG=en_US.utf8


### PR DESCRIPTION
https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=477072

Moving to openSUSE Tumbleweed, which comes with Python 3.10, which we need in order to run this version of the Talon library:

https://github.com/rorytorneymf/talon/releases/tag/1.6.0-with-8138ea9a604f037f47f544dfb805f13d26696275-reverted