### PR TITLE
US738057: Return to latest opensuse leap

### DIFF
--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -22,7 +22,7 @@ ARG DOCKER_HUB_PUBLIC=docker.io
 # - Install desired packages
 # - Specify policy for cryptographic back-ends
 #
-FROM ${DOCKER_HUB_PUBLIC}/opensuse/leap:15.4 AS stage1
+FROM ${DOCKER_HUB_PUBLIC}/opensuse/leap:latest AS stage1
 
 # Set the locale manually to a set inherited from the base image (defaults to POSIX)
 ENV LANG=en_US.utf8


### PR DESCRIPTION
Ticket: https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=738057