### PR TITLE
US857046: Update gosu to 1.17

### DIFF
--- a/release-notes-2.9.0.md
+++ b/release-notes-2.9.0.md
@@ -4,5 +4,7 @@
 ${version-number}
 
 #### New Features
+- US857046: Update gosu to version [1.17](https://github.com/tianon/gosu/releases/tag/1.17).
 
 #### Known Issues
+- None

--- a/release-notes-2.9.0.md
+++ b/release-notes-2.9.0.md
@@ -4,7 +4,12 @@
 ${version-number}
 
 #### New Features
-- US857046: Update gosu to version [1.17](https://github.com/tianon/gosu/releases/tag/1.17).
+- US857046: Update gosu to version [1.17](https://github.com/tianon/gosu/releases/tag/1.17).  
+This has resolved the following CVE issues:
+  - [CVE-2023-27561](https://access.redhat.com/security/cve/CVE-2023-27561)
+  - [CVE-2022-29162](https://access.redhat.com/security/cve/CVE-2022-29162)
+  - [CVE-2023-28642](https://access.redhat.com/security/cve/CVE-2023-28642)
+  - [CVE-2023-25809](https://access.redhat.com/security/cve/CVE-2023-25809)
 
 #### Known Issues
 - None

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -52,8 +52,8 @@ RUN zypper -n install dirmngr
 # Download and verify gosu
 RUN gpg --batch --keyserver-options http-proxy=${env.HTTP_PROXY} --keyserver hkps://keys.openpgp.org \
         --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 && \
-    curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.16/gosu-amd64" && \
-    curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.16/gosu-amd64.asc" && \
+    curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.17/gosu-amd64" && \
+    curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.17/gosu-amd64.asc" && \
     gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu && \
     chmod +x /usr/local/bin/gosu
 


### PR DESCRIPTION
Ticket: https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=857046

See attached trivvy scans from before and after upgrade, the scan is now reporting clean.
[trivvy_scan_after.json](https://github.com/CAFapi/opensuse-base-image/files/13307754/trivvy_scan_after.json)
[trivvy_scan_before.json](https://github.com/CAFapi/opensuse-base-image/files/13307755/trivvy_scan_before.json)
