### PR TITLE
I863043: Incorrect Tini Version in the Base Images

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,7 @@
                                     <http_proxy>${env.HTTP_PROXY}</http_proxy>
                                     <https_proxy>${env.HTTPS_PROXY}</https_proxy>
                                     <no_proxy>${env.NO_PROXY}</no_proxy>
+                                    <TINI_VERSION>v0.19.0</TINI_VERSION>
                                 </args>
                             </build>
                         </image>

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,6 @@
                                     <http_proxy>${env.HTTP_PROXY}</http_proxy>
                                     <https_proxy>${env.HTTPS_PROXY}</https_proxy>
                                     <no_proxy>${env.NO_PROXY}</no_proxy>
-                                    <TINI_VERSION>v0.19.0</TINI_VERSION>
                                 </args>
                             </build>
                         </image>

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -73,10 +73,9 @@ RUN chmod +x /startup/* /startup/startup.d/*
 
 # Add Tini
 ENV TINI_VERSION v0.19.0
-ADD https://github.com/krallin/tini/releases/download/$TINI_VERSION/tini /tini/
-ADD https://github.com/krallin/tini/archive/refs/tags/$TINI_VERSION.zip /tini/
+ADD https://github.com/krallin/tini/releases/download/$TINI_VERSION/tini /tini
 RUN chmod +x /tini
-#ENTRYPOINT ["/tini", "--", "/startup/startup.sh"]
+ENTRYPOINT ["/tini", "--", "/startup/startup.sh"]
 
 # Add other useful scripts
 COPY scripts /scripts

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -72,7 +72,7 @@ ADD https://raw.githubusercontent.com/CAFapi/caf-common/v1.19.0/container-cert-s
 RUN chmod +x /startup/* /startup/startup.d/*
 
 # Add Tini
-ENV TINI_VERSION v0.19.0
+ARG TINI_VERSION
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini/
 ADD https://github.com/krallin/tini/archive/refs/tags/${TINI_VERSION}.zip /tini/
 RUN chmod +x /tini

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -73,9 +73,10 @@ RUN chmod +x /startup/* /startup/startup.d/*
 
 # Add Tini
 ENV TINI_VERSION v0.19.0
-ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini/
+ADD https://github.com/krallin/tini/archive/refs/tags/${TINI_VERSION}.zip /tini/
 RUN chmod +x /tini
-ENTRYPOINT ["/tini", "--", "/startup/startup.sh"]
+#ENTRYPOINT ["/tini", "--", "/startup/startup.sh"]
 
 # Add other useful scripts
 COPY scripts /scripts

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -72,9 +72,9 @@ ADD https://raw.githubusercontent.com/CAFapi/caf-common/v1.19.0/container-cert-s
 RUN chmod +x /startup/* /startup/startup.d/*
 
 # Add Tini
-ARG TINI_VERSION
-ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini/
-ADD https://github.com/krallin/tini/archive/refs/tags/${TINI_VERSION}.zip /tini/
+ENV TINI_VERSION v0.19.0
+ADD https://github.com/krallin/tini/releases/download/$TINI_VERSION/tini /tini/
+ADD https://github.com/krallin/tini/archive/refs/tags/$TINI_VERSION.zip /tini/
 RUN chmod +x /tini
 #ENTRYPOINT ["/tini", "--", "/startup/startup.sh"]
 


### PR DESCRIPTION
Ticket: https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=863043

This is very weird, reduced the dockerfile back to this:
![image](https://github.com/CAFapi/opensuse-base-image/assets/22191766/2a882f16-caee-4cb4-beb9-a072a9a87372)

This resulted in this in the build log:
![image (1)](https://github.com/CAFapi/opensuse-base-image/assets/22191766/929dedcc-1f9a-4e92-bb3e-ab44e0ca1ceb)

Therefore had to make the change to be simply `$TINI_VERSION` and not `${TINI_VERSION}` to get this to work properly. However I did note in the build log that is trying to download `ADD https://github.com/krallin/tini/releases/download/$TINI_VERSION/tini /tini` which again is weird but it seems to be the correct version in my test image when I also downloaded the zip file.

No idea where the v0.18.0 was coming from however.